### PR TITLE
Handle SSE streams without DONE from iflow domain

### DIFF
--- a/internal/proxy/proxy_logic.go
+++ b/internal/proxy/proxy_logic.go
@@ -24,7 +24,7 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 	// 检查是否为 count_tokens 请求到 OpenAI 端点
 	isCountTokensRequest := strings.Contains(path, "/count_tokens")
 	isOpenAIEndpoint := ep.EndpointType == "openai"
-	
+
 	// OpenAI 端点不支持 count_tokens，立即尝试下一个端点
 	if isCountTokensRequest && isOpenAIEndpoint {
 		s.logger.Debug(fmt.Sprintf("Skipping count_tokens request on OpenAI endpoint %s", ep.Name))
@@ -39,13 +39,13 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 	// 为这个端点记录独立的开始时间
 	endpointStartTime := time.Now()
 	targetURL := ep.GetFullURL(path)
-	
+
 	// Extract tags from taggedRequest
 	var tags []string
 	if taggedRequest != nil {
 		tags = taggedRequest.Tags
 	}
-	
+
 	// 创建HTTP请求用于模型重写处理
 	tempReq, err := http.NewRequest(c.Request.Method, targetURL, bytes.NewReader(requestBody))
 	if err != nil {
@@ -90,18 +90,17 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 		finalRequestBody = requestBody // 使用原始请求体
 	}
 
-
 	// 格式转换（在模型重写之后）
 	var conversionContext *conversion.ConversionContext
 	if s.converter.ShouldConvert(ep.EndpointType) {
 		s.logger.Info(fmt.Sprintf("Starting request conversion for endpoint type: %s", ep.EndpointType))
-		
+
 		// 创建端点信息
 		endpointInfo := &conversion.EndpointInfo{
 			Type:               ep.EndpointType,
 			MaxTokensFieldName: ep.MaxTokensFieldName,
 		}
-		
+
 		convertedBody, ctx, err := s.converter.ConvertRequest(finalRequestBody, endpointInfo)
 		if err != nil {
 			s.logger.Error("Request format conversion failed", err)
@@ -117,8 +116,8 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 		finalRequestBody = convertedBody
 		conversionContext = ctx
 		s.logger.Debug("Request format converted successfully", map[string]interface{}{
-			"endpoint_type": ep.EndpointType,
-			"original_size": len(requestBody),
+			"endpoint_type":  ep.EndpointType,
+			"original_size":  len(requestBody),
 			"converted_size": len(convertedBody),
 		})
 	}
@@ -135,7 +134,7 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 			finalRequestBody = hackedBody
 			s.logger.Debug("OpenAI user parameter length hack applied")
 		}
-		
+
 		// GPT-5 模型特殊处理 hack
 		gpt5HackedBody, err := s.applyGPT5ModelHack(finalRequestBody)
 		if err != nil {
@@ -160,7 +159,7 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 		} else {
 			finalRequestBody = overriddenBody
 			s.logger.Info("Request parameter overrides applied", map[string]interface{}{
-				"endpoint": ep.Name,
+				"endpoint":        ep.Name,
 				"overrides_count": len(parameterOverrides),
 			})
 		}
@@ -263,19 +262,19 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 		ep.AuthType == "oauth" &&
 		ep.OAuthConfig != nil &&
 		ep.OAuthConfig.RefreshToken != "" {
-		
+
 		// 检查是否已经因为这个端点的认证问题刷新过token
 		refreshKey := fmt.Sprintf("oauth_refresh_attempted_%s", ep.ID)
 		if _, alreadyRefreshed := c.Get(refreshKey); !alreadyRefreshed {
 			s.logger.Info(fmt.Sprintf("Authentication failed (HTTP %d) for OAuth endpoint %s, attempting token refresh", resp.StatusCode, ep.Name))
-			
+
 			// 标记我们已经为这个端点尝试过token刷新，避免无限循环
 			c.Set(refreshKey, true)
-			
+
 			// 尝试刷新token
 			if refreshErr := ep.RefreshOAuthTokenWithCallback(s.config.Timeouts.ToProxyTimeoutConfig(), s.createOAuthTokenRefreshCallback()); refreshErr != nil {
 				s.logger.Error(fmt.Sprintf("Failed to refresh OAuth token for endpoint %s: %v", ep.Name, refreshErr), refreshErr)
-				
+
 				// 刷新失败，读取响应体用于日志记录
 				duration := time.Since(endpointStartTime)
 				body, _ := io.ReadAll(resp.Body)
@@ -284,7 +283,7 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 				if err != nil {
 					decompressedBody = body // 如果解压失败，使用原始数据
 				}
-				
+
 				s.logSimpleRequest(requestID, ep.URL, c.Request.Method, path, requestBody, finalRequestBody, c, req, resp, decompressedBody, duration, nil, s.isRequestExpectingStream(req), tags, "", originalModel, rewrittenModel, attemptNumber)
 				// 设置错误信息到context中
 				c.Set("last_error", fmt.Errorf("OAuth token refresh failed: %v", refreshErr))
@@ -292,10 +291,10 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 				return false, true
 			} else {
 				s.logger.Info(fmt.Sprintf("OAuth token refreshed successfully for endpoint %s, retrying request", ep.Name))
-				
+
 				// 关闭原始响应体
 				resp.Body.Close()
-				
+
 				// Token刷新成功，递归重试相同的endpoint（重新走完整的请求流程）
 				return s.proxyToEndpoint(c, ep, path, requestBody, requestID, startTime, taggedRequest, attemptNumber)
 			}
@@ -303,19 +302,19 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 			s.logger.Debug(fmt.Sprintf("OAuth token refresh already attempted for endpoint %s in this request, not retrying", ep.Name))
 		}
 	}
-	
+
 	// 只有2xx状态码才认为是成功，其他所有状态码都尝试下一个端点
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		duration := time.Since(endpointStartTime)
 		body, _ := io.ReadAll(resp.Body)
-		
+
 		// 解压响应体用于日志记录
 		contentEncoding := resp.Header.Get("Content-Encoding")
 		decompressedBody, err := s.validator.GetDecompressedBody(body, contentEncoding)
 		if err != nil {
 			decompressedBody = body // 如果解压失败，使用原始数据
 		}
-		
+
 		s.logSimpleRequest(requestID, ep.URL, c.Request.Method, path, requestBody, finalRequestBody, c, req, resp, decompressedBody, duration, nil, s.isRequestExpectingStream(req), tags, "", originalModel, rewrittenModel, attemptNumber)
 		s.logger.Debug(fmt.Sprintf("HTTP error %d from endpoint %s, trying next endpoint", resp.StatusCode, ep.Name))
 		// 设置状态码到context中，供重试逻辑使用
@@ -355,14 +354,14 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 	// 智能检测内容类型并自动覆盖
 	currentContentType := resp.Header.Get("Content-Type")
 	newContentType, overrideInfo := s.validator.SmartDetectContentType(decompressedBody, currentContentType, resp.StatusCode)
-	
+
 	// 确定最终的Content-Type和是否为流式响应
 	finalContentType := currentContentType
 	if newContentType != "" {
 		finalContentType = newContentType
 		s.logger.Info(fmt.Sprintf("Auto-detected content type mismatch for endpoint %s: %s", ep.Name, overrideInfo))
 	}
-	
+
 	// 判断是否为流式响应（基于最终的Content-Type）
 	isStreaming := strings.Contains(strings.ToLower(finalContentType), "text/event-stream")
 
@@ -380,16 +379,16 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 			}
 		}
 	}
-	
+
 	// 监控Anthropic rate limit headers
 	if ep.ShouldMonitorRateLimit() {
 		if err := s.processRateLimitHeaders(ep, resp.Header, requestID); err != nil {
 			s.logger.Error("Failed to process rate limit headers", err)
 		}
 	}
-	
+
 	// 严格 Anthropic 格式验证已永久启用
-	if err := s.validator.ValidateResponseWithPath(decompressedBody, isStreaming, ep.EndpointType, path); err != nil {
+	if err := s.validator.ValidateResponseWithPath(decompressedBody, isStreaming, ep.EndpointType, path, ep.URL); err != nil {
 		// 如果是usage统计验证失败，尝试下一个endpoint
 		if strings.Contains(err.Error(), "invalid usage stats") {
 			s.logger.Info(fmt.Sprintf("Usage validation failed for endpoint %s: %v", ep.Name, err))
@@ -401,7 +400,7 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 			c.Set("last_status_code", resp.StatusCode)
 			return false, true // 验证失败，尝试下一个endpoint
 		}
-		
+
 		// 如果是SSE流不完整的验证失败，尝试下一个endpoint
 		if strings.Contains(err.Error(), "incomplete SSE stream") || strings.Contains(err.Error(), "missing message_stop") || strings.Contains(err.Error(), "missing [DONE]") || strings.Contains(err.Error(), "missing finish_reason") {
 			s.logger.Info(fmt.Sprintf("Incomplete SSE stream detected for endpoint %s: %v", ep.Name, err))
@@ -413,7 +412,7 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 			c.Set("last_status_code", resp.StatusCode)
 			return false, true // SSE流不完整，尝试下一个endpoint
 		}
-		
+
 		// 验证失败，尝试下一个端点
 		s.logger.Info(fmt.Sprintf("Response validation failed for endpoint %s, trying next endpoint: %v", ep.Name, err))
 		duration := time.Since(endpointStartTime)
@@ -426,7 +425,7 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 	}
 
 	c.Status(resp.StatusCode)
-	
+
 	// 格式转换（在模型重写之前）
 	convertedResponseBody := decompressedBody
 	if conversionContext != nil {
@@ -446,13 +445,13 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 			convertedResponseBody = convertedResp
 			s.logger.Info(fmt.Sprintf("Response conversion successful! Original: %d bytes -> Converted: %d bytes", len(decompressedBody), len(convertedResp)))
 			s.logger.Debug("Response format converted successfully", map[string]interface{}{
-				"endpoint_type": conversionContext.EndpointType,
-				"original_size": len(decompressedBody),
+				"endpoint_type":  conversionContext.EndpointType,
+				"original_size":  len(decompressedBody),
 				"converted_size": len(convertedResp),
 			})
 		}
 	}
-	
+
 	// 应用响应模型重写（如果进行了请求模型重写）
 	finalResponseBody := convertedResponseBody
 	if originalModel != "" && rewrittenModel != "" {
@@ -474,7 +473,7 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 		// 只有格式转换没有模型重写的情况
 		finalResponseBody = convertedResponseBody
 	}
-	
+
 	// 设置正确的响应头部
 	if conversionContext != nil || (originalModel != "" && rewrittenModel != "") {
 		// 如果进行了转换或模型重写，需要重新设置头部
@@ -483,7 +482,7 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 		// 设置正确的内容长度
 		c.Header("Content-Length", fmt.Sprintf("%d", len(finalResponseBody)))
 	}
-	
+
 	// 如果是流式响应，确保设置正确的SSE头部
 	if isStreaming {
 		c.Header("Content-Type", "text/event-stream; charset=utf-8")
@@ -493,10 +492,10 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 		// 移除Content-Length头部（SSE不应该设置这个）
 		c.Header("Content-Length", "")
 	}
-	
+
 	// 发送最终响应体给客户端
 	c.Writer.Write(finalResponseBody)
-	
+
 	// 清除错误信息（成功情况）
 	c.Set("last_error", nil)
 	c.Set("last_status_code", resp.StatusCode)
@@ -508,7 +507,7 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 	requestLog.Tags = tags
 	requestLog.ContentTypeOverride = overrideInfo
 	requestLog.AttemptNumber = attemptNumber
-	
+
 	// 设置 thinking 信息
 	if thinkingInfo, exists := c.Get("thinking_info"); exists {
 		if info, ok := thinkingInfo.(*utils.ThinkingInfo); ok && info != nil {
@@ -516,7 +515,7 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 			requestLog.ThinkingBudgetTokens = info.BudgetTokens
 		}
 	}
-	
+
 	// 记录原始客户端请求数据
 	requestLog.OriginalRequestURL = c.Request.URL.String()
 	requestLog.OriginalRequestHeaders = utils.HeadersToMap(c.Request.Header)
@@ -529,7 +528,7 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 			}
 		}
 	}
-	
+
 	// 记录最终发送给上游的请求数据
 	requestLog.FinalRequestURL = req.URL.String()
 	requestLog.FinalRequestHeaders = utils.HeadersToMap(req.Header)
@@ -542,7 +541,7 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 			}
 		}
 	}
-	
+
 	// 记录上游原始响应数据
 	requestLog.OriginalResponseHeaders = utils.HeadersToMap(resp.Header)
 	if len(decompressedBody) > 0 {
@@ -554,7 +553,7 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 			}
 		}
 	}
-	
+
 	// 记录最终发送给客户端的响应数据
 	finalHeaders := make(map[string]string)
 	for key := range resp.Header {
@@ -573,13 +572,13 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 			}
 		}
 	}
-	
+
 	// 设置兼容性字段
 	requestLog.RequestHeaders = requestLog.FinalRequestHeaders
 	requestLog.RequestBody = requestLog.OriginalRequestBody
 	requestLog.ResponseHeaders = requestLog.OriginalResponseHeaders
 	requestLog.ResponseBody = requestLog.OriginalResponseBody
-	
+
 	// 设置模型信息
 	if len(requestBody) > 0 {
 		extractedModel := utils.ExtractModelFromRequestBody(string(requestBody))
@@ -590,16 +589,16 @@ func (s *Server) proxyToEndpoint(c *gin.Context, ep *endpoint.Endpoint, path str
 			requestLog.Model = extractedModel
 			requestLog.OriginalModel = extractedModel
 		}
-		
+
 		if rewrittenModel != "" {
 			requestLog.RewrittenModel = rewrittenModel
 			requestLog.ModelRewriteApplied = rewrittenModel != requestLog.OriginalModel
 		}
-		
+
 		// 提取 Session ID
 		requestLog.SessionID = utils.ExtractSessionIDFromRequestBody(string(requestBody))
 	}
-	
+
 	// 更新基本字段
 	s.logger.UpdateRequestLog(requestLog, req, resp, decompressedBody, duration, nil)
 	requestLog.IsStreaming = isStreaming
@@ -697,17 +696,17 @@ func (s *Server) applyOpenAIUserLengthHack(requestBody []byte) ([]byte, error) {
 	hasher.Write([]byte(userStr))
 	hashBytes := hasher.Sum(nil)
 	hashStr := hex.EncodeToString(hashBytes)
-	
+
 	// 添加前缀标识
 	hashedUser := "hashed-" + hashStr
 
 	// 更新请求数据
 	requestData["user"] = hashedUser
-	
+
 	s.logger.Info("OpenAI user parameter hashed due to length limit", map[string]interface{}{
 		"original_length": len(userStr),
-		"hashed_length": len(hashedUser),
-		"original_user": userStr[:min(32, len(userStr))] + "...", // 只记录前32个字符用于调试
+		"hashed_length":   len(hashedUser),
+		"original_user":   userStr[:min(32, len(userStr))] + "...", // 只记录前32个字符用于调试
 	})
 
 	// 重新序列化为JSON
@@ -783,7 +782,7 @@ func (s *Server) applyGPT5ModelHack(requestBody []byte) ([]byte, error) {
 	}
 
 	s.logger.Info("GPT-5 model hack applied", map[string]interface{}{
-		"model": modelStr,
+		"model":   modelStr,
 		"changes": hackDetails,
 	})
 
@@ -809,7 +808,7 @@ func min(a, b int) int {
 func (s *Server) processRateLimitHeaders(ep *endpoint.Endpoint, headers http.Header, requestID string) error {
 	resetHeader := headers.Get("Anthropic-Ratelimit-Unified-Reset")
 	statusHeader := headers.Get("Anthropic-Ratelimit-Unified-Status")
-	
+
 	// 转换reset为int64
 	var resetValue *int64
 	if resetHeader != "" {
@@ -817,51 +816,51 @@ func (s *Server) processRateLimitHeaders(ep *endpoint.Endpoint, headers http.Hea
 			resetValue = &parsed
 		} else {
 			s.logger.Debug("Failed to parse Anthropic-Ratelimit-Unified-Reset header", map[string]interface{}{
-				"value": resetHeader,
-				"error": err.Error(),
-				"endpoint": ep.Name,
+				"value":      resetHeader,
+				"error":      err.Error(),
+				"endpoint":   ep.Name,
 				"request_id": requestID,
 			})
 		}
 	}
-	
+
 	var statusValue *string
 	if statusHeader != "" {
 		statusValue = &statusHeader
 	}
-	
+
 	// 更新endpoint状态
 	changed, err := ep.UpdateRateLimitState(resetValue, statusValue)
 	if err != nil {
 		return err
 	}
-	
+
 	// 如果状态发生变化，持久化到配置文件
 	if changed {
 		s.logger.Info("Rate limit state changed, persisting to config", map[string]interface{}{
-			"endpoint": ep.Name,
-			"reset": resetValue,
-			"status": statusValue,
+			"endpoint":   ep.Name,
+			"reset":      resetValue,
+			"status":     statusValue,
 			"request_id": requestID,
 		})
-		
+
 		// 持久化到配置文件
 		if err := s.persistRateLimitState(ep.ID, resetValue, statusValue); err != nil {
 			s.logger.Error("Failed to persist rate limit state", err)
 			return err
 		}
 	}
-	
+
 	// 检查增强保护：如果启用了增强保护且状态为allowed_warning，则禁用端点
 	if ep.ShouldDisableOnAllowedWarning() && ep.IsAvailable() {
 		s.logger.Info("Enhanced protection triggered: disabling endpoint due to allowed_warning status", map[string]interface{}{
-			"endpoint": ep.Name,
-			"status": statusValue,
+			"endpoint":            ep.Name,
+			"status":              statusValue,
 			"enhanced_protection": true,
-			"request_id": requestID,
+			"request_id":          requestID,
 		})
 		ep.MarkInactive()
 	}
-	
+
 	return nil
 }


### PR DESCRIPTION
## Summary
- pass endpoint URL through validation so SSE checks know request origin
- ignore missing `[DONE]` marker for OpenAI-style SSE streams from `apis.iflow.cn`
- add tests for the iflow domain exception

## Testing
- `go test -v ./...` *(fails: TestConvertAnthropicRequestToOpenAI_SimpleText: MaxCompletionTokens should not be nil)*

------
https://chatgpt.com/codex/tasks/task_e_68c2dd6c3d38832698f8aa9348ac513e